### PR TITLE
Requirements file has double requirements

### DIFF
--- a/setup/requirments.txt
+++ b/setup/requirments.txt
@@ -5,7 +5,6 @@ chardet==3.0.4
 configparser==3.5.0
 dnspython==1.15.0
 docx2txt==0.6
-fake-useragent==0.1.7
 html5lib==0.999999999
 idna==2.6
 mechanize==0.3.6


### PR DESCRIPTION
fake-useragent==0.1.7 and fake-useragent==0.1.8 are both required. Removing 0.1.7 solved this issue.

Also the filename has a typo and should be 'requirements', but I am not sure how this impacts other scripts besides setup/setup.sh on line 54.